### PR TITLE
Change version range of trpc packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "SolidJS tRPC",
   "author": "OrJDev",
   "license": "MIT",
-  "version": "0.0.10-rc.1",
+  "version": "0.0.10-rc.2",
   "publishConfig": {
     "access": "public",
     "tag": "next"
@@ -40,8 +40,8 @@
   },
   "peerDependencies": {
     "@tanstack/solid-query": "^4.6.1",
-    "@trpc/client": "10.0.0-rc.2",
-    "@trpc/server": "10.0.0-rc.2",
+    "@trpc/client": "^10.0.0-rc.2",
+    "@trpc/server": "^10.0.0-rc.2",
     "solid-js": "^1.5.3"
   },
   "keywords": [


### PR DESCRIPTION
[Create-jd-app](https://github.com/OrJDev/create-jd-app) has the `@trpc/client` and `@trpc/server` set to `^10.0.0-rc.2` while `solid-trpc` was using a fixed version `10.0.0-rc.2`.

The solution would be to either set the versions of these packages in `create-jd-app` to a fixed version, or keep them intact and open up the version range here in `solid-trpc`. The latter seems more favourable, hence this MR. It does however require a update to `create-jd-app` as well since this version of `solid-trpc` is also pinned.